### PR TITLE
thread id obtained on each event to ensure it is accurate

### DIFF
--- a/lib/hodel_3000_compliant_logger.rb
+++ b/lib/hodel_3000_compliant_logger.rb
@@ -19,7 +19,7 @@ class Hodel3000CompliantLogger < Logger
   end
 
   def process_id
-    "#{$PID}#{Thread.current.object_id}"
+    "#{$PID}:#{Thread.current.object_id}"
   end
 
   def msg2str(msg)


### PR DESCRIPTION
caching the id doesn't always provide correct results (it assumes that
the app creates an instance of Hodel3000CompliantLogger per thread)

In jruby, the actual OS thread ID can be obtained from

  JRuby.reference(Thread.current).native_thread.id

however Thread.curent.object_id is a sufficient proxy
